### PR TITLE
feat: implement military time validator

### DIFF
--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/.gitignore
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+TODO.md

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -13,4 +13,10 @@ describe("military time validator", () => {
     const result = militaryTimeValidator.validateTimeRange();
     expect(result).toEqual("yes");
   });
+
+  it("should return 'no' when validating '25:00 - 12:23'", () => {
+    const militaryTimeValidator = new MilitaryTimeValidator("25:00 - 12:23");
+    const result = militaryTimeValidator.validateTimeRange();
+    expect(result).toEqual("no");
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -7,4 +7,10 @@ describe("military time validator", () => {
     const result = militaryTimeValidator.validateTimeRange();
     expect(result).toEqual("yes");
   });
+
+  it("should return 'yes' when validating '22:00 - 23:12'", () => {
+    const militaryTimeValidator = new MilitaryTimeValidator("22:00 - 23:12");
+    const result = militaryTimeValidator.validateTimeRange();
+    expect(result).toEqual("yes");
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -1,5 +1,10 @@
+import { describe, it, expect } from "@jest/globals";
+import MilitaryTimeValidator from "./index";
 
-describe('military time validator', () => {
-
-
-})
+describe("military time validator", () => {
+  it("should return 'yes' when validating '01:12 - 14:32'", () => {
+    const militaryTimeValidator = new MilitaryTimeValidator("01:12 - 14:32");
+    const result = militaryTimeValidator.validate;
+    expect(result).toEqual("yes");
+  });
+});

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -2,21 +2,21 @@ import { describe, it, expect } from "@jest/globals";
 import MilitaryTimeValidator from "./index";
 
 describe("military time validator", () => {
-  it("should return 'yes' when validating '01:12 - 14:32'", () => {
-    const militaryTimeValidator = new MilitaryTimeValidator("01:12 - 14:32");
-    const result = militaryTimeValidator.validateTimeRange();
-    expect(result).toEqual("yes");
-  });
+  const testCases = [
+    ["01:12 - 14:32", "yes"],
+    ["22:00 - 23:12", "yes"],
+    ["25:00 - 12:23", "no"],
+    ["24:00 - 00:00", "no"],
+    ["12:00 - 12:00", "no"],
+    ["12:59 - 12:00", "no"],
+  ];
 
-  it("should return 'yes' when validating '22:00 - 23:12'", () => {
-    const militaryTimeValidator = new MilitaryTimeValidator("22:00 - 23:12");
-    const result = militaryTimeValidator.validateTimeRange();
-    expect(result).toEqual("yes");
-  });
-
-  it("should return 'no' when validating '25:00 - 12:23'", () => {
-    const militaryTimeValidator = new MilitaryTimeValidator("25:00 - 12:23");
-    const result = militaryTimeValidator.validateTimeRange();
-    expect(result).toEqual("no");
-  });
+  it.each(testCases)(
+    "should return '%s' when validating '%s'",
+    (timeRange, expected) => {
+      const militaryTimeValidator = new MilitaryTimeValidator(timeRange);
+      const result = militaryTimeValidator.validateTimeRange();
+      expect(result).toEqual(expected);
+    }
+  );
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -4,7 +4,7 @@ import MilitaryTimeValidator from "./index";
 describe("military time validator", () => {
   it("should return 'yes' when validating '01:12 - 14:32'", () => {
     const militaryTimeValidator = new MilitaryTimeValidator("01:12 - 14:32");
-    const result = militaryTimeValidator.validate;
+    const result = militaryTimeValidator.validateTimeRange();
     expect(result).toEqual("yes");
   });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,3 +1,5 @@
+type ValidateResult = "yes" | "no";
+
 class MilitaryTimeValidator {
   private timeRange: string;
 
@@ -5,8 +7,33 @@ class MilitaryTimeValidator {
     this.timeRange = timeRange;
   }
 
-  get validate(): string {
-    return "yes";
+  public validateTimeRange(): ValidateResult {
+    const result =
+      this.isValidStartTime() &&
+      this.isValidEndTime() &&
+      this.isEndTimeAfterStartTime();
+
+    return result ? "yes" : "no";
+  }
+
+  private isValidStartTime(): boolean {
+    return true;
+  }
+
+  private isValidEndTime(): boolean {
+    return true;
+  }
+
+  private isEndTimeAfterStartTime() {
+    return this.endTime > this.startTime;
+  }
+
+  get endTime(): string {
+    return "2";
+  }
+
+  get startTime(): string {
+    return "1";
   }
 }
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,0 +1,13 @@
+class MilitaryTimeValidator {
+  private timeRange: string;
+
+  constructor(timeRange: string) {
+    this.timeRange = timeRange;
+  }
+
+  get validate(): string {
+    return "yes";
+  }
+}
+
+export default MilitaryTimeValidator;

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -17,11 +17,16 @@ class MilitaryTimeValidator {
   }
 
   private isValidStartTime(): boolean {
-    return true;
+    return this.isValidTimeFormat(this.startTime);
   }
 
   private isValidEndTime(): boolean {
-    return true;
+    return this.isValidTimeFormat(this.endTime);
+  }
+
+  private isValidTimeFormat(time: string): boolean {
+    const regex = /^([01]\d|2[0-3]):([0-5]\d)$/;
+    return regex.test(time);
   }
 
   private isEndTimeAfterStartTime() {
@@ -29,11 +34,13 @@ class MilitaryTimeValidator {
   }
 
   get endTime(): string {
-    return "2";
+    const times = this.timeRange.split(" - ");
+    return times[1];
   }
 
   get startTime(): string {
-    return "1";
+    const times = this.timeRange.split(" - ");
+    return times[0];
   }
 }
 


### PR DESCRIPTION
# Checklist

🔘 **I have tests that validate the following statements:**
- "01:12 - 14:32" (yes)
- "25:00 - 12:23" (no)
- "22:00 - 23:12" (yes)
- (optionally) confirmed/verified this for more tests

🔘 **I have Programmed By Wishful Thinking**, designing the response API before it was actually created

🔘 **I have Worked Backwards**, starting at the Assert, then going to the Act and the Arrange

🔘 **Once I have made the aforementioned tests pass, I have refactored my test specifications to use `it.each()` to perform parameterization if there is sufficient duplication**

🔘 **There is no duplication in my test code or my production code**

🔘 **I have attempted to implement the simplest possible Transformations according to the Transformation Priority Premise table**
